### PR TITLE
Responsive action buttons

### DIFF
--- a/components/Pointer/Pointer.tsx
+++ b/components/Pointer/Pointer.tsx
@@ -1,11 +1,11 @@
-import { usePathValidate } from "@/hooks/usePathValidate";
-import { useStore } from "@/store/StoreProvider/StoreProvider";
-import withStore from "@/store/StoreProvider/withStore";
-import { calculateAveragePoints } from "@/utilities/commonUtils";
 import { Box, Button, Typography, styled } from "@mui/material";
 import React from "react";
 import PointButton from "./PointButton/PointButton";
 import PointerMenu from "./PointerMenu/PointerMenu";
+import { useStore } from "@/store/StoreProvider/StoreProvider";
+import withStore from "@/store/StoreProvider/withStore";
+import { usePathValidate } from "@/hooks/usePathValidate";
+import { calculateAveragePoints } from "@/utilities/commonUtils";
 
 const points = [
   { label: "1", value: "1" },

--- a/components/Pointer/Pointer.tsx
+++ b/components/Pointer/Pointer.tsx
@@ -1,11 +1,11 @@
+import { usePathValidate } from "@/hooks/usePathValidate";
+import { useStore } from "@/store/StoreProvider/StoreProvider";
+import withStore from "@/store/StoreProvider/withStore";
+import { calculateAveragePoints } from "@/utilities/commonUtils";
 import { Box, Button, Typography, styled } from "@mui/material";
 import React from "react";
 import PointButton from "./PointButton/PointButton";
 import PointerMenu from "./PointerMenu/PointerMenu";
-import { useStore } from "@/store/StoreProvider/StoreProvider";
-import withStore from "@/store/StoreProvider/withStore";
-import { usePathValidate } from "@/hooks/usePathValidate";
-import { calculateAveragePoints } from "@/utilities/commonUtils";
 
 const points = [
   { label: "1", value: "1" },
@@ -53,6 +53,7 @@ const ButtonContainer = styled(Box)(() => {
     display: "flex",
     flexDirection: "row-reverse",
     gap: "10px",
+    flexWrap: "wrap",
   };
 });
 


### PR DESCRIPTION
I like to use the pointer at narrow widths, but the action buttons get squished when I make the window too narrow. This PR will let the action buttons flow into a column without the button text overflowing the button borders.